### PR TITLE
AM-67: dot shadow

### DIFF
--- a/lib/utils/svg_symbols.mjs
+++ b/lib/utils/svg_symbols.mjs
@@ -252,10 +252,6 @@ function geolocation() {
 function circle(style) {
   const icon = svg.node`
   <svg width=24 height=24 viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'>
-    <circle cx=16 cy=16 r=10
-      stroke="#333"
-      stroke-width="${style.strokeWidth || 1}"
-      fill="none"></circle>
     <circle cx=15 cy=15 r=10
       stroke="${style.strokeColor || '#333'}"
       stroke-width="${style.strokeWidth || 1}"


### PR DESCRIPTION
This PR removes the duplicate SVG circle from the dots view: the SVG circle on the back has static color and is 1 px larger than the SVG which we can change the style via config file, made it look like a box shadow was being added